### PR TITLE
fix: use top level entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-dist/
+dist

--- a/packages/vue-shining-text/index.mjs
+++ b/packages/vue-shining-text/index.mjs
@@ -1,0 +1,1 @@
+export * from './dist'

--- a/packages/vue-shining-text/package.json
+++ b/packages/vue-shining-text/package.json
@@ -5,14 +5,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./index.mjs"
     }
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "index.mjs"
   ],
   "scripts": {
     "build": "unbuild"


### PR DESCRIPTION
resolves https://github.com/vargasmesh/shining-text/issues/1

By creating a top level `.mjs` entry, we can trick vite into resolving `.ts` (stubbed) files and also have a valid production package.